### PR TITLE
TEP: NFTRoyalty Standard Extension

### DIFF
--- a/text/0066-nft-royalty-standard.md
+++ b/text/0066-nft-royalty-standard.md
@@ -1,6 +1,6 @@
-- **TEP**: [66](https://github.com/ton-blockchain/TEPs/pull/0)
+- **TEP**: [66](https://github.com/ton-blockchain/TEPs/pull/6)
 - **title**: NFTRoyalty Standard Extension
-- **status**: Draft
+- **status**: Review
 - **type**: Contract Interface
 - **authors**: [EmelyanenkoK](https://github.com/EmelyanenkoK), [Tolya](https://github.com/tolya-yanot)
 - **created**: 12.02.2022


### PR DESCRIPTION
Extension for [NFT Standard](https://github.com/ton-blockchain/TIPs/issues/62).

Moved from [TIP-66](https://github.com/ton-blockchain/TIPs/issues/66).