### PR TITLE
Little clarification on get_royalty_params

### DIFF
--- a/text/0066-nft-royalty-standard.md
+++ b/text/0066-nft-royalty-standard.md
@@ -19,8 +19,8 @@ It is convenient to standardize royalty, so all NFT markets will pay royalty to 
 
 # Guide
 
-1. report_royalty_params example implementation: [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract/blob/2c13d3ef61ca4288293ad65bf0cfeaed83879b93/nft/nft-collection.fc#L58-L68).
-2. get_royalty_params example implementation: [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract/blob/2c13d3ef61ca4288293ad65bf0cfeaed83879b93/nft/nft-collection.fc#L149-L153).
+1. get_royalty_params (on-chain) example implementation: [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract/blob/2c13d3ef61ca4288293ad65bf0cfeaed83879b93/nft/nft-collection.fc#L58-L68).
+2. royalty_params (GET method for off-chain use) example implementation: [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract/blob/2c13d3ef61ca4288293ad65bf0cfeaed83879b93/nft/nft-collection.fc#L149-L153).
 
 Royalty data example in Fift:
 ```


### PR DESCRIPTION
A little clarification about the methods in the guidebook. Practice has shown that developers get confused because real name of GET method different.