### PR TITLE
Update 0064 add render type for Jetton

### DIFF
--- a/text/0064-token-data-standard.md
+++ b/text/0064-token-data-standard.md
@@ -131,14 +131,13 @@ Note, that while TL-B scheme does not constrain bit size of each chunk it is exp
 6. `symbol` - Optional. UTF8 string. The symbol of the token - e.g. "XMPL". Used in the form "You received 99 XMPL".
 7. `decimals` - Optional. If not specified, 9 is used by default. UTF8 encoded string with number from 0 to 255. The number of decimals the token uses - e.g. 8, means to divide the token amount by 100000000 to get its user representation, while 0 means that tokens are indivisible: user representation of token number should correspond to token amount in wallet-contract storage.
    In case you specify decimals, it is highly recommended that you specify this parameter on-chain and that the smart contract code ensures that this parameter is immutable.
-8. `render_type` - Optional. Needed by external applications to understand which group the jetton belongs to and how to display it.  
+8. `amount_style` - Optional. Needed by external applications to understand which format for displaying the number of jettons. 
+ - "n" - number of jettons (default value). If the user has 100 tokens with decimals 0, then display that user has 100 tokens
+ - "n-of-total" - the number of jettons out of the total number of issued jettons. For example, totalSupply Jetton = 1000. A user has 100 jettons in the jetton wallet. For example must be displayed in the user's wallet as 100 of 1000 or in any other textual or graphical way to demonstrate the particular from the general.
+ - "%" - percentage of jettons from the total number of issued jettons. For example, totalSupply Jetton = 1000. A user has 100 jettons in the jetton wallet. For example it should be displayed in the user's wallet as 10%.
+9. `render_type` - Optional. Needed by external applications to understand which group the jetton belongs to and how to display it.  
  - "currency" - display as currency (default value). 
- - "game" - display for games. 
- - "finance" - display for finance.
-9. `amount_style` - Optional. Needed by external applications to understand which format for displaying the number of jettons. 
- - "n" - number of jettons (default value).
- - "n-of-total" - the number of jettons out of the total number of issued jettons.
- - "%" - percentage of jettons from the total number of issued jettons.
+ - "game" - display for games. It should be displayed as NFT, but at the same time display the number of jettons considering the `amount_style`
 
 # Drawbacks
 

--- a/text/0064-token-data-standard.md
+++ b/text/0064-token-data-standard.md
@@ -131,8 +131,14 @@ Note, that while TL-B scheme does not constrain bit size of each chunk it is exp
 6. `symbol` - Optional. UTF8 string. The symbol of the token - e.g. "XMPL". Used in the form "You received 99 XMPL".
 7. `decimals` - Optional. If not specified, 9 is used by default. UTF8 encoded string with number from 0 to 255. The number of decimals the token uses - e.g. 8, means to divide the token amount by 100000000 to get its user representation, while 0 means that tokens are indivisible: user representation of token number should correspond to token amount in wallet-contract storage.
    In case you specify decimals, it is highly recommended that you specify this parameter on-chain and that the smart contract code ensures that this parameter is immutable.
-8. `render_type` - Optional. Needed by external applications to understand which group the jetton belongs to and how to display it. The default is "currency" - display as currency. "game" - display for games. "finance" - display for finance.
-9. `amount_style` - Optional. Needed by external applications to understand which format for displaying the number of jettons. Default value "n" - number of jettons. "n-of-total" - the number of jettons out of the total number of issued jettons. "%" - percentage of jettons from the total number of issued jettons.
+8. `render_type` - Optional. Needed by external applications to understand which group the jetton belongs to and how to display it.  
+ - "currency" - display as currency (default value). 
+ - "game" - display for games. 
+ - "finance" - display for finance.
+9. `amount_style` - Optional. Needed by external applications to understand which format for displaying the number of jettons. 
+ - "n" - number of jettons (default value).
+ - "n-of-total" - the number of jettons out of the total number of issued jettons.
+ - "%" - percentage of jettons from the total number of issued jettons.
 
 # Drawbacks
 

--- a/text/0064-token-data-standard.md
+++ b/text/0064-token-data-standard.md
@@ -131,6 +131,8 @@ Note, that while TL-B scheme does not constrain bit size of each chunk it is exp
 6. `symbol` - Optional. UTF8 string. The symbol of the token - e.g. "XMPL". Used in the form "You received 99 XMPL".
 7. `decimals` - Optional. If not specified, 9 is used by default. UTF8 encoded string with number from 0 to 255. The number of decimals the token uses - e.g. 8, means to divide the token amount by 100000000 to get its user representation, while 0 means that tokens are indivisible: user representation of token number should correspond to token amount in wallet-contract storage.
    In case you specify decimals, it is highly recommended that you specify this parameter on-chain and that the smart contract code ensures that this parameter is immutable.
+8. `render_type` - Optional. Needed by external applications to understand which group the jetton belongs to and how to display it. The default is "currency" - display as currency. "game" - display for games. "finance" - display for finance.
+9. `amount_style` - Optional. Needed by external applications to understand which format for displaying the number of jettons. Default value "n" - number of jettons. "n-of-total" - the number of jettons out of the total number of issued jettons. "%" - percentage of jettons from the total number of issued jettons.
 
 # Drawbacks
 
@@ -162,3 +164,5 @@ None
 * 14 May 2022 - the standard is now used not only for NFT, but for all tokens in the TON. Added section "Jetton metadata attributes".
 
 * 31 Aug 2022 - added note about data encoded in TL-B schema in "Data serialization" paragraph.
+
+* 14 Oct 2022 - render_type and amount_style for Jetton metadata


### PR DESCRIPTION
The idea is to allow projects to flag how best to display their tokens in wallets, markets, etc.
This small introduction will increase the attractiveness of projects for which visual display is important.
These objects are optional.

For example, in games it is important that the tokens are displayed as a large card and look more like an NFT than a currency. At the same time, the game can also have a currency.