### PR TITLE
Lockable Jetton Wallet

### DIFF
--- a/text/0000-lockable-jetton-wallet.md
+++ b/text/0000-lockable-jetton-wallet.md
@@ -1,5 +1,5 @@
 - **TEP**: [0](https://github.com/ton-blockchain/TEPs/pull/0) *(don't change)*
-- **title**: Lockable Jettons Wallets
+- **title**: Lockable Jetton Wallet
 - **status**: Draft
 - **type**: Contract Interface
 - **authors**: [KuznetsovNikita](https://github.com/KuznetsovNikita)
@@ -9,7 +9,7 @@
 
 # Summary
 
-This proposal suggests extending the standard Jetton Wallet by adding the option `get_locked_balance` get method.
+This proposal suggests extending the Jetton Wallet by adding the option `get_locked_balance` get method.
 
 # Motivation
 


### PR DESCRIPTION
# Summary

This proposal suggests extending the Jetton Wallet by adding the option `get_locked_balance` get method.

# Motivation

New contracts have may want to disable jetton transfer until a time in the future. For this case, the Jetton Wallet should show zero balance to not affect old services and add a new get method to allow to get a locked balance and expiration date.

The standard may use for:
1. Jetton DAO contract may want to disable jetton transfer until voting is in progress.
2. Jetton Vesting contract may want to release tokens in the future.