### PR TITLE
address update proposal

### DIFF
--- a/text/0002-address.md
+++ b/text/0002-address.md
@@ -33,7 +33,7 @@ B) "User-friendly", which is obtained by first generating:
 - 32 bytes containing 256 bits of the smart-contract address inside the workchain (big-endian)
 - 2 bytes containing CRC16-CCITT of the previous 34 bytes
 
-In case B), the 36 bytes thus obtained are then encoded using base64 (i.e., with digits, upper- and lowercase Latin letters, '/' and '+') or base64url (with '_' and '-' instead of '/' and '+'), yielding 48 printable non-space characters.
+In case B), the 36 bytes thus obtained are then encoded using base64url (with '_' and '-' instead of '/' and '+'), yielding 48 printable non-space characters.
 
 Example:
 
@@ -51,27 +51,30 @@ and
 
 in the "user-friendly" form (to be displayed by user-friendly clients). 
 
-Notice that both forms (base64 and base64url) are valid and must be accepted.
-
 ## Wallets applications
 
 At the moment, TON wallets work with addresses as follows:
 
 For receiving:
 
-- Wallets display the user's address in a user-friendly bounceable or non-bounceable form (at the moment, the majority of wallet apps display bounceable form).
+- Wallets display the user's address in a user-friendly non-bounceable form.
+
+- Addresses of other smart contracts (DEXes, NFT, etc.) are displayed in a user-friendly bounceable form.
 
 When sending:
 
-1) The wallet app checks the validity of the destination address representation - its length, valid characters, prefix and checksum. If the address is not valid, then an alert is shown and the sending operation is not performed.
+1) The wallet apps accept only user-friendly address form and don't accept "raw" address form. 
 
-2) If the address has a testnet flag, and the wallet app works with the mainnet network, then an alert is shown and the sending operation is not performed.
+2) The wallet app checks the validity of the destination address representation - its length, valid characters, prefix and checksum. If the address is not valid, then an alert is shown and the sending operation is not performed.
 
-3) The wallet app retrieve from address bounceable flag.
+3) If the address has a testnet flag, and the wallet app works with the mainnet network, then an alert is shown and the sending operation is not performed.
 
-4) The wallet app check the destination address - if it has `unitialized` state wallet force set `bounce` field of sending message to `false` and ignore bounceable/non-bounceable flag from address representation.
+4) The wallet app retrieve from address bounceable flag.
+   if `true` - all messages to this address can ONLY be sent in bounceable mode, even if the destination contract has an `uninitialized` state.
 
-5) If destination is not `unitialized` then wallet app uses the bounceable/non-bounceable flag from the address representation for the `bounce` field of sending message.
+   if `false` - means that a non-bounceable message can be sent to the destination address.
+
+   The wallet app checks the destination address - if it has an `uninitialized` state, then it sends a non-bounceable message, otherwise it sends a bounceable message.
 
 ## Public keys
 


### PR DESCRIPTION
# Proposal that will prevent the loss of user funds in case of erroneous sending

TON is a blockchain for massadoption, so we propose a number of guidelines and small changes in the address format,
so that even if the inexperienced user is inattentive and sends funds to the wrong place, the funds were not lost and bounced back to him in most cases.

This proposal describes changes that almost do not break backward compatibility. However, at the same time we can discuss other proposals, including more radical ones.



Examples of cases where a user can lose funds:

1) The user copied the address in the testnet service, but mistakenly interacts with it or sends coins to it from the mainnet wallet app.

   Since there will be no such address in the mainnet, the wallet app will now set the non-bounceable mode and send coins that will remain at the destination address and will be lost

2) Let's imagine a smart contract for the sale of NFT (for example, belonging to some marketplace), after receiving Toncoins from the buyer, this contract sends NFT to the buyer and destroy itself, because its mission is completed.

   However, the UI may not be updated immediately and another user may send Toncoins for purchase to this contract address. Since the contract will no longer exist, the wallet app will set non-bounceable mode and Toncoins will remain forever at the destination address and will be lost.

   At the moment, most marketplaces bypass this by not destroying the sale smart contract.

3) The smart contract of the service (e.g. DEX) has not been deployed yet, but the user has already sent coins there, the wallet app will set non-bounceable mode and Toncoins will remain forever at the destination address and will be lost.


Suggested behaviour:

1) All TON apps and services must show addresses with a testnet flag set if they are on a testnet network.

2) All TON apps and services should reject addresses with a testnet flag set if they are on a mainnet network.
     For example, mainnet wallets should not allow sending coins to a testnet address in any way.

3) User apps and services should only accept addresses in user-friendly format and not accept addresses in raw format.

4) All services must only display and accept urlsafe format, and not operate with non-urlsafe form.

5) All wallets should show non-bounceable addresses.

6) All other smart contracts should always show in bounceable form.
    The creators of such smart contracts (for example, DEXes) must first deploy such smart contracts themselves in order for the bounceable form of the address to be applicable.

7) `bounceable` flag from address representation should now be taken as "force-bounceable".

    When sending, wallets must accept this flag as follows:

    if `true` - all messages to this address can ONLY be sent in bounceable mode, even if the destination contract has an `uninitialized` state.

    if `false` - means that a non-bounceable message can be sent to the destination address.
        The wallet app checks the destination address - if it has an `uninitialized` state, then it sends a non-bounceable message, otherwise it sends a bounceable message.

    Since only wallets will use the non-bounceable form, it will also be possible to distinguish the wallet from the service smart contract using this flag.

## Migration Plan

Since there are already many services and applications in the TON network, it makes sense to carry out the migration in stages:

1) All popular services must apply a testnet flag to the addresses on their testnet versions.

2) All popular wallets and services (such DEX'es or NFT marketplaces) must reject destination testnet addresses in mainnet.

3) All popular services must not display and accept "raw" address form and non-urlsafe form.

4) All popular wallets must show user's address in non-bounceable form.

    This modifies only the leading and last characters of the address, while the body of the address remains the same.

   However, changing the address may confuse some users, so advance warning and explanation in public channels is needed.

5) All popular exchanges and services must show deposit addresses in non-bounceable form.

7) All popular exchanges should not allow withdrawals to non-wallet addresses (to non-bounceable addresses).

8) After that all popular wallets must implement new `bounceable` flag algo.

## Suggested behaviour of TON DNS:

The DNS recode scheme assumed a `cap_is_wallet` flag (which allow to send non-bounceable messages).

```
cap_method_seqno#5371 = SmcCapability;
cap_method_pubkey#71f4 = SmcCapability;
cap_is_wallet#2177 = SmcCapability;
cap_name#ff name:Text = SmcCapability;


cap_list_nil$0 = SmcCapList;
cap_list_next$1 head:SmcCapability tail:SmcCapList = SmcCapList;

dns_smc_address#9fd3 smc_addr:MsgAddressInt flags:(## 8) { flags <= 1 }
  cap_list:flags . 0?SmcCapList = DNSRecord;
```

However, this flag was not widely used and applied in practice.

Based on the fact that DNS names are mainly used for user wallets and to a much lesser extent for service addresses, we propose to introduce the flag

`cap_only_bounceable`

which will mean that non-bounceable message should never be sent to this address.

DNS records of addresses of existing services can be updated, because this is in the interests of the services themselves.

## Suggested behaviour of TON Connect

TON Connect methods (such as `sendTransaction`) must accept a domain or address in user-friendly form as the destination address, and not accept the raw form.

A dapp that calls such a method either received this address from the user, or knows the type of smart contract (for example, it sends a transaction to the DEX smart contract, which means bounceable form).