### PR TITLE
Revert "Specify that `prove_ownership` must be rejected on SBT if not sent by owner"

### DIFF
--- a/text/0085-sbt-standard.md
+++ b/text/0085-sbt-standard.md
@@ -34,10 +34,8 @@ forward_payload:^Cell with_content:Bool = InternalMsgBody;
 
 `with_content` - if true, SBT's content cell will be included in message to contract.
 
-**Should be rejected if:**
-* Sender address is not the owner's address.
+**Should do:**
 
-**Otherwise should do:**
 Send message with TL-B schema to `dest` contract:
 ```
 ownership_proof#0524c7ae query_id:uint64 item_id:uint256 owner:MsgAddress 


### PR DESCRIPTION
Reverts ton-blockchain/TEPs#117