### PR TITLE
fix: changed outdated link for TEP 74 Jetton contract

### DIFF
--- a/text/0074-jettons-standard.md
+++ b/text/0074-jettons-standard.md
@@ -23,7 +23,7 @@ Jetton standard describes:
 # Guide
 
 ## Useful links
-1. [Reference jetton implementation](https://github.com/ton-blockchain/token-contract/)
+1. [Reference jetton implementation](https://github.com/ton-blockchain/jetton-contract/)
 2. [Jetton deployer](https://jetton.live/)
 3. FunC Jetton lesson ([en](https://github.com/romanovichim/TonFunClessons_Eng/blob/main/lessons/smartcontract/9lesson/ninthlesson.md)/[ru](https://github.com/romanovichim/TonFunClessons_ru/blob/main/lessons/smartcontract/9lesson/ninthlesson.md))
 


### PR DESCRIPTION
The link used to go to the first and outdated Jetton implementation.