### PR TITLE
Add license for template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -46,3 +46,7 @@ If there are some questions that have to be discussed during review process or t
 # Future possibilities
 
 Do you have ideas, which things can be implemented on top of this TEP later? Write possible ideas of new TEPs, which are related to this TEP.
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
According to #418 this repo has no license.

Because relicensing all existing TEPs requires permission by the authors of all these TEPs, I started by adding it to the template, so next TEPs will be licensed that way.

Why license?
Many Open Source projects (including blockchain projects) add license for their "TEPs". For example:
- Ethereum: CC0 - https://github.com/ethereum/EIPs/blob/master/LICENSE.md
- Bitcoin: BSD, Public Domain (some BIPs are unlicensed)
- BSC: CC0
Even programming languages, e.g. Python (PEP) are placed in the public domain.

Why CC0?

It is a popular option in strong ecosystems like Ethereum, BSC, and it is perfect for that proposals.


For this change, I need only @hacker-volodya approval, as the only author of template.